### PR TITLE
Only return IP address of running instance

### DIFF
--- a/aws.sh
+++ b/aws.sh
@@ -27,6 +27,7 @@ awsip() {
   aws ec2 describe-instances \
     --region us-east-1 \
     --filters "Name=tag:Name,Values=${host}" \
+              'Name=instance-state-name,Values=running' \
     --query 'Reservations[*].Instances[*].[PrivateIpAddress]' \
     --output text | head -1
 }


### PR DESCRIPTION
`awsip` previously attempted to return the IP address of instances that weren't running. This caused a problem when replacing an instance with one of the same name.

`awsip` now checks to make sure the instance state is Running.